### PR TITLE
namespaced types for erlang 17+

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
+{erl_opts, [{platform_define, "^[0-9]+", namespaced_types}]}.
 {xref_checks, [undefined_function_calls,
                undefined_functions,
                locals_not_used,

--- a/src/hyper_gb.erl
+++ b/src/hyper_gb.erl
@@ -66,8 +66,11 @@ fold_1(_, Acc, _) ->
 bytes({T, _}) ->
     erts_debug:flat_size(T) * 8.
 
-
+-ifdef(namespaced_types).
+-spec register_sum({gb_trees:tree(),number()}) -> float().
+-else.
 -spec register_sum({gb_tree(),number()}) -> float().
+-endif.
 register_sum({T, M}) ->
     {MaxI, Sum} = fold(fun (Index, Value, {I, Acc}) ->
                             Zeroes = Index - I - 1,


### PR DESCRIPTION
Make it able to compile on newer Erlang without warning. 
